### PR TITLE
Add CODEOWNERS and initial documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file defines code owners for the repository
+# Code owners are automatically requested for review when someone opens a pull request
+
+# Global owner for all files
+* @pych-ky

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Tools Playground
+
+Experimental repository for various tools.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting Security Vulnerabilities
+
+Please report security vulnerabilities via GitHub Issues or contact the repository owner directly.


### PR DESCRIPTION
## Summary
- Add CODEOWNERS file to define code ownership for PR reviews
- Add README.md with project description
- Add SECURITY.md with security policy

## Changes
- Created `.github/CODEOWNERS` to set @pych-ky as the default code owner
- Added basic README.md file
- Added SECURITY.md file

## Purpose
This PR sets up the foundation for code review requirements and basic documentation for the repository.

🤖 Generated with [Claude Code](https://claude.ai/code)