### PR TITLE
Update GitHub workflow triggers and permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,10 +2,11 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [labeled, synchronize]
 
 jobs:
   claude-review:
+    if: contains(github.event.pull_request.labels.*.name, 'claude-review')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude:
-    if: contains(toJson(github.event), '@claude')
+    if: contains(toJSON(github.event), '@claude')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,5 +26,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          additional_permissions: |
+            actions: read
           custom_instructions: |
             Please respond in Japanese.


### PR DESCRIPTION
## Summary
- Change Claude Code Review workflow to trigger on `labeled` event instead of `opened`, with conditional check for `claude-review` label
- Fix `toJson` to `toJSON` in Claude workflow condition for proper JSON parsing
- Add `actions: read` permission to Claude workflow for enhanced functionality

## Test plan
- [ ] Verify Claude Code Review workflow only runs when `claude-review` label is applied
- [ ] Confirm Claude workflow still triggers properly with @claude mentions
- [ ] Test that additional permissions work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)