### PR TITLE
Remove redundant github_token from Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           additional_permissions: |
             actions: read
           custom_instructions: |


### PR DESCRIPTION
## Summary
- Claude workflowから不要なgithub_tokenパラメータを削除

## Test plan
- [ ] GitHub Actionsでワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ワークフロー設定の内部処理を更新しました。エンドユーザー向けの機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->