### PR TITLE
feat: Add issue creation trigger to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,6 +8,8 @@ permissions:
   actions: read
 
 on:
+  issues:
+    types: [opened]
   issue_comment:
     types: [created]
   pull_request_review_comment:


### PR DESCRIPTION
## Summary
- Issue作成時に@claudeメンションがbodyに含まれる場合もClaudeワークフローを発火させるようにしました
- `on.issues.types: [opened]`を追加しました

## Test plan
- [ ] 新しいIssueを作成し、bodyに`@claude`を含めた時にワークフローが発火することを確認
- [ ] 既存のIssueコメントに`@claude`を含めた時にワークフローが発火することを確認
- [ ] PRレビューコメントに`@claude`を含めた時にワークフローが発火することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)