### PR TITLE
Remove issue opened trigger from Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,8 +8,6 @@ permissions:
   actions: read
 
 on:
-  issues:
-    types: [opened]
   issue_comment:
     types: [created]
   pull_request_review_comment:


### PR DESCRIPTION
## Summary
- Remove the `issues: [opened]` trigger from the Claude workflow

## Test plan
- The workflow will continue to work with issue comments and PR review comments
- New issues will no longer automatically trigger the Claude workflow

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ワークフローのトリガー条件を変更し、新規のイシュー作成時の実行を削除しました。今後は新規のイシューコメントおよびプルリクエストレビューコメント作成時のみワークフローが実行されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->