### PR TITLE
feat: Add mcp__github__create_pull_request tool to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,5 +24,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
+          allowed_tools: |
+            mcp__github__create_pull_request
           custom_instructions: |
             Please respond in Japanese.


### PR DESCRIPTION
## Summary
- Claude workflowにmcp__github__create_pull_requestツールを追加
- allowed_tools設定を使用してGitHub MCP統合のPR作成機能を有効化

## Test plan
- [ ] GitHub Actionsでworkflowが正常に動作することを確認
- [ ] Claude が PR を作成できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actionsワークフローに新しい入力パラメータ`allowed_tools`を追加し、特定のツール利用を許可しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->