### PR TITLE
feat: Prevent bot accounts from triggering Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   claude:
-    if: contains(toJSON(github.event), '@claude')
+    if: contains(toJSON(github.event), '@claude') && github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add condition to check if sender is not a Bot before running Claude workflow
- Prevents infinite loops when bots comment on issues

## Test plan
- [ ] Verify that human users can still trigger Claude with @claude mentions
- [ ] Confirm that bot accounts cannot trigger the workflow
- [ ] Check that the workflow still runs correctly for valid triggers

🤖 Generated with [Claude Code](https://claude.ai/code)