### PR TITLE
feat: Restrict Claude workflow to repository owner

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,7 +15,9 @@ on:
 
 jobs:
   claude:
-    if: contains(toJSON(github.event), '@claude') && github.event.sender.type != 'Bot'
+    if: >-
+      contains(github.event.comment.body, '@claude') &&
+      github.event.comment.author_association == 'OWNER'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Modified Claude workflow to only trigger on comments from repository owner
- Changed from bot account detection to `author_association == 'OWNER'` check
- Provides more granular control over who can trigger the Claude workflow

## Test plan
- [ ] Test that owner comments with '@claude' trigger the workflow
- [ ] Verify that non-owner comments with '@claude' do not trigger the workflow
- [ ] Confirm workflow runs successfully when triggered by owner

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * GitHub Actionsワークフローの実行条件が変更され、"@claude"を含むコメントかつリポジトリ所有者によるコメントのみでジョブが実行されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->