### PR TITLE
feat: Add global cursor rules configuration

### DIFF
--- a/.cursor/rules/global.mdc
+++ b/.cursor/rules/global.mdc
@@ -1,6 +1,6 @@
 ---
 description: Global coding rules for AI assistants
-globs:
+globs: **/*
 alwaysApply: true
 ---
 

--- a/.cursor/rules/global.mdc
+++ b/.cursor/rules/global.mdc
@@ -1,0 +1,17 @@
+---
+description: Global coding rules for AI assistants
+globs:
+alwaysApply: true
+---
+
+# Response Marker Rule
+
+IMPORTANT: Every AI response MUST start with exactly "[AI-RESPONSE]" (without quotes) on its own line before any other content.
+This applies to ALL responses including code reviews, explanations, and general answers.
+
+Example:
+
+```text
+[AI-RESPONSE]
+Here is my analysis of your code...
+```


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/global.mdc` configuration file with a verifiable AI response marker rule
- Set `alwaysApply: true` to ensure the rule is always active
- The rule requires all AI responses to start with `[AI-RESPONSE]` for easy verification

## Test plan
- [ ] Verify that AI assistants (Cursor, CodeRabbit, Copilot) recognize and follow the rule
- [ ] Confirm the `[AI-RESPONSE]` marker appears at the beginning of AI responses
- [ ] Check that the rule applies globally across all file types

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **新機能**
  * すべてのAIアシスタントの応答が、必ず最初に"[AI-RESPONSE]"というマーカーを単独行で表示する形式に統一されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->