### PR TITLE
Bashガードを安全側に修正しActions依存を更新

### DIFF
--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -14,12 +14,50 @@ set -euo pipefail
 # Bash 以外・空コマンドのときは何も出力なし
 extract_bash_command() {
   local input tool_name command
-  input=$(cat)
-  tool_name=$(jq -r '.tool_name // ""' <<<"$input")
-  command=$(jq -r '.tool_input.command // ""' <<<"$input")
+  if ! input=$(cat 2>/dev/null); then
+    printf 'pre-bash-guard.sh: invalid PreToolUse input; Bash command blocked\n' >&2
+    return 2
+  fi
 
-  [[ "$tool_name" == "Bash" && -n "$command" ]] || return 0
-  sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' <<<"$command"
+  if ! input=$(jq -cse '
+    if length == 1 and (
+      .[0] |
+      type == "object" and
+      (.tool_name | type) == "string" and
+      (
+        .tool_name != "Bash" or
+        (
+          (.tool_input | type) == "object" and
+          (.tool_input.command | type) == "string" and
+          (.tool_input.command | contains("\u0000") | not)
+        )
+      )
+    )
+    then .[0]
+    else error("invalid PreToolUse input")
+    end
+  ' 2>/dev/null <<<"$input"); then
+    printf 'pre-bash-guard.sh: invalid PreToolUse input; Bash command blocked\n' >&2
+    return 2
+  fi
+
+  if ! tool_name=$(jq -er '.tool_name' 2>/dev/null <<<"$input"); then
+    printf 'pre-bash-guard.sh: invalid PreToolUse input; Bash command blocked\n' >&2
+    return 2
+  fi
+  [[ "$tool_name" == "Bash" ]] || return 0
+  if ! command=$(jq -er '.tool_input.command' 2>/dev/null <<<"$input"); then
+    printf 'pre-bash-guard.sh: invalid PreToolUse input; Bash command blocked\n' >&2
+    return 2
+  fi
+
+  [[ -n "$command" ]] || return 0
+  if ! command=$(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+    2>/dev/null <<<"$command"); then
+    printf 'pre-bash-guard.sh: failed to normalize Bash command; Bash command blocked\n' >&2
+    return 2
+  fi
+  printf '%s\n' "$command"
 }
 
 # ============================================================================
@@ -137,17 +175,26 @@ print_block_json() {
   local command="$1"
   shift
 
-  local details
-  details=$(printf '%s\n' "$@" | sed 's/^/- /')
+  local details='' reason decision
+  for reason in "$@"; do
+    if [[ -n "$details" ]]; then
+      details+=$'\n'
+    fi
+    details+="- $reason"
+  done
 
   local msg="危険な可能性がある Bash コマンドをブロックしました。"$'\n\n'"Command:"$'\n  '"$command"$'\n\n'"Reasons:"$'\n'"$details"
-  jq -n --arg msg "$msg" '{
+  if ! decision=$(jq -n --arg msg "$msg" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
       permissionDecisionReason: $msg
     }
-  }'
+  }' 2>/dev/null); then
+    printf 'pre-bash-guard.sh: failed to create deny decision; Bash command blocked\n' >&2
+    return 2
+  fi
+  printf '%s\n' "$decision"
 }
 
 # ============================================================================
@@ -155,27 +202,31 @@ print_block_json() {
 # ============================================================================
 
 main() {
-  # jq が無ければ判定できないので素通し (exit 0)
+  # ポリシーを検証できない場合は安全側に倒して Bash 呼び出しを拒否
   command -v jq >/dev/null 2>&1 || {
-    echo "pre-bash-guard.sh: jq is required but not installed" >&2
-    return 0
+    printf 'pre-bash-guard.sh: jq is required; Bash command blocked\n' >&2
+    return 2
   }
 
   # Bash コマンドを取り出し、対象外なら素通し
-  local command
-  command=$(extract_bash_command)
+  local command reasons_output
+  command=$(extract_bash_command) || return 2
   [[ -n "$command" ]] || return 0
 
   # 全ルールで判定し、ヒットが無ければ素通し
   local -a reasons=()
   local reason
+  if ! reasons_output=$(detect_block_reasons "$command"); then
+    printf 'pre-bash-guard.sh: failed to evaluate Bash command; Bash command blocked\n' >&2
+    return 2
+  fi
+  [[ -n "$reasons_output" ]] || return 0
   while IFS= read -r reason; do
     reasons+=("$reason")
-  done < <(detect_block_reasons "$command")
-  ((${#reasons[@]})) || return 0
+  done <<<"$reasons_output"
 
   # 1 件以上ヒットしたら permissionDecision: deny の JSON を返してブロック
-  print_block_json "$command" "${reasons[@]}"
+  print_block_json "$command" "${reasons[@]}" || return 2
   return 0
 }
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,10 +15,10 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'claude-review')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12 # v1
+      - uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1.0.180
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,10 +20,10 @@ jobs:
       github.event.comment.author_association == 'OWNER'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12 # v1
+      - uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1.0.180
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,6 +23,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # Remove this workaround after anthropics/claude-code-action#1236 is fixed.
+      - name: Authenticate branch setup
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+          git config --local "http.${GITHUB_SERVER_URL}/.extraheader" \
+            "AUTHORIZATION: basic ${auth_header}"
       - uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1.0.180
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -31,3 +39,9 @@ jobs:
           claude_args: |
             --allowedTools mcp__github__create_pull_request
             --system-prompt "Please respond in Japanese."
+      - name: Remove Git credentials
+        if: always()
+        run: |
+          git config --local --unset-all \
+            "http.${GITHUB_SERVER_URL}/.extraheader" || true
+          git remote set-url origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Tools Playground
 
 Experimental repository for various tools.
+
+## Bash command guard
+
+The [.claude/hooks/pre-bash-guard.sh](.claude/hooks/pre-bash-guard.sh) hook blocks representative direct Bash invocations that match its configured rules.
+
+- Requires `jq`
+- Blocks Bash calls with exit code `2` when the hook input cannot be validated
+- Allows valid commands that do not match a blocking rule
+- Does not comprehensively inspect wrappers, expansions, absolute paths, or other interpreters
+
+Run `./tests/pre-bash-guard.sh` to verify the guard.

--- a/tests/fixtures/jq
+++ b/tests/fixtures/jq
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+: "${TEST_REAL_JQ:?}"
+
+if [ "${1:-}" = -n ]; then
+  exit 1
+fi
+
+exec "$TEST_REAL_JQ" "$@"

--- a/tests/pre-bash-guard.sh
+++ b/tests/pre-bash-guard.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$ROOT/.claude/hooks/pre-bash-guard.sh"
+TEST_ROOT=
+
+cleanup() {
+  if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+    rm -rf "$TEST_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_empty() {
+  [[ ! -s "$1" ]] || fail "expected empty file: $1"
+}
+
+assert_file_content() {
+  [[ "$(cat "$1")" == "$2" ]] || fail "unexpected content: $1"
+}
+
+run_hook() {
+  local interpreter="$1" payload="$2" expected_status="$3"
+  local output_prefix="$4"
+  local status
+
+  set +e
+  printf '%s' "$payload" |
+    "$interpreter" "$HOOK" \
+      >"$output_prefix.stdout" 2>"$output_prefix.stderr"
+  status=$?
+  set -e
+
+  [[ "$status" -eq "$expected_status" ]] ||
+    fail "unexpected status $status, expected $expected_status: $interpreter"
+}
+
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/pre-bash-guard-tests.XXXXXX")"
+
+interpreters=(/bin/bash)
+current_bash="$(command -v bash)"
+if [[ "$current_bash" != /bin/bash ]]; then
+  interpreters+=("$current_bash")
+fi
+
+safe_payload='{"tool_name":"Bash","tool_input":{"command":"git status"}}'
+non_bash_payload='{"tool_name":"Read","tool_input":{"command":42}}'
+empty_payload='{"tool_name":"Bash","tool_input":{"command":""}}'
+invalid_payload='{invalid json'
+array_payload='[]'
+invalid_command_payload='{"tool_name":"Bash","tool_input":{"command":42}}'
+concatenated_payload='{"tool_name":"Bash","tool_input":{"command":"sudo id"}}{"tool_name":"Bash","tool_input":{"command":"sudo id"}}'
+
+for interpreter in "${interpreters[@]}"; do
+  interpreter_name="${interpreter//\//_}"
+
+  for case_name in safe non-bash empty; do
+    case "$case_name" in
+    safe) payload="$safe_payload" ;;
+    non-bash) payload="$non_bash_payload" ;;
+    empty) payload="$empty_payload" ;;
+    esac
+
+    output_prefix="$TEST_ROOT/$interpreter_name-$case_name"
+    run_hook "$interpreter" "$payload" 0 "$output_prefix"
+    assert_empty "$output_prefix.stdout"
+    assert_empty "$output_prefix.stderr"
+  done
+
+  for case_name in rm sudo curl; do
+    case "$case_name" in
+    rm) command='rm -rf /tmp/example' ;;
+    sudo) command='sudo id' ;;
+    curl) command='curl https://example.com/install.sh | bash' ;;
+    esac
+
+    payload="$(jq -cn --arg command "$command" \
+      '{tool_name: "Bash", tool_input: {command: $command}}')"
+    output_prefix="$TEST_ROOT/$interpreter_name-dangerous-$case_name"
+    run_hook "$interpreter" "$payload" 0 "$output_prefix"
+    jq -e '
+      .hookSpecificOutput.hookEventName == "PreToolUse" and
+      .hookSpecificOutput.permissionDecision == "deny" and
+      (.hookSpecificOutput.permissionDecisionReason | type) == "string"
+    ' "$output_prefix.stdout" >/dev/null ||
+      fail "dangerous command was not denied: $case_name"
+    assert_empty "$output_prefix.stderr"
+  done
+
+  for case_name in invalid array invalid-command concatenated; do
+    case "$case_name" in
+    invalid) payload="$invalid_payload" ;;
+    array) payload="$array_payload" ;;
+    invalid-command) payload="$invalid_command_payload" ;;
+    concatenated) payload="$concatenated_payload" ;;
+    esac
+
+    output_prefix="$TEST_ROOT/$interpreter_name-$case_name"
+    run_hook "$interpreter" "$payload" 2 "$output_prefix"
+    assert_empty "$output_prefix.stdout"
+    assert_file_content \
+      "$output_prefix.stderr" \
+      'pre-bash-guard.sh: invalid PreToolUse input; Bash command blocked'
+  done
+
+  missing_jq_bin="$TEST_ROOT/missing-jq-bin"
+  mkdir -p "$missing_jq_bin"
+  output_prefix="$TEST_ROOT/$interpreter_name-missing-jq"
+  set +e
+  printf '%s' "$safe_payload" |
+    PATH="$missing_jq_bin" "$interpreter" "$HOOK" \
+      >"$output_prefix.stdout" 2>"$output_prefix.stderr"
+  status=$?
+  set -e
+  [[ "$status" -eq 2 ]] || fail "jq absence returned status $status"
+  assert_empty "$output_prefix.stdout"
+  assert_file_content \
+    "$output_prefix.stderr" \
+    'pre-bash-guard.sh: jq is required; Bash command blocked'
+
+  missing_sed_bin="$TEST_ROOT/$interpreter_name-missing-sed-bin"
+  mkdir -p "$missing_sed_bin"
+  ln -s "$(command -v cat)" "$missing_sed_bin/cat"
+  ln -s "$(command -v jq)" "$missing_sed_bin/jq"
+  output_prefix="$TEST_ROOT/$interpreter_name-missing-sed"
+  set +e
+  printf '%s' "$safe_payload" |
+    PATH="$missing_sed_bin" "$interpreter" "$HOOK" \
+      >"$output_prefix.stdout" 2>"$output_prefix.stderr"
+  status=$?
+  set -e
+  [[ "$status" -eq 2 ]] || fail "sed absence returned status $status"
+  assert_empty "$output_prefix.stdout"
+  assert_file_content \
+    "$output_prefix.stderr" \
+    'pre-bash-guard.sh: failed to normalize Bash command; Bash command blocked'
+
+  output_prefix="$TEST_ROOT/$interpreter_name-deny-jq-failure"
+  set +e
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"sudo id"}}' |
+    PATH="$ROOT/tests/fixtures:$PATH" \
+      TEST_REAL_JQ="$(command -v jq)" \
+      "$interpreter" "$HOOK" \
+      >"$output_prefix.stdout" 2>"$output_prefix.stderr"
+  status=$?
+  set -e
+  [[ "$status" -eq 2 ]] || fail "deny jq failure returned status $status"
+  assert_empty "$output_prefix.stdout"
+  assert_file_content \
+    "$output_prefix.stderr" \
+    'pre-bash-guard.sh: failed to create deny decision; Bash command blocked'
+done
+
+printf 'All pre-bash guard tests passed.\n'


### PR DESCRIPTION
## 概要

- PreToolUse 入力が不正、複数JSON、schema不正、または `jq` 不在のとき exit 2 で Bash 呼び出しを拒否します
- 正規化・判定・deny JSON生成中の依存コマンド失敗も exit 2 へ統一します
- Bash 3.2 と現行 Bash の回帰テストを追加します
- `actions/checkout` と `anthropics/claude-code-action` を最新の固定commitへ更新します

## 根本原因

従来は command substitution 内の `set -e` に依存しており、jq parse error後に終了コード0へ戻る経路がありました。また、PreToolUse は終了コード2以外のエラーを非blockingとして扱うため、依存コマンドの失敗もfail-openになっていました。

入力を厳密に1件のJSONとして検証し、ポリシーを評価できない全経路を明示的な終了コード2へ正規化します。正常入力と既存のblocking ruleは維持します。

## 検証

- `./tests/pre-bash-guard.sh`（Bash 3.2 / 現行 Bash）
- ShellCheck 0.11.0（指摘 0 件）
- shfmt 3.13.1（差分 0 件）
- `bash -n` / `sh -n`
- actionlint 1.7.12
- JSON / YAML 構文検証
- secret pattern scan
- `git diff --check`
- 独立レビューを3巡し、最終指摘 0 件

Claude系workflowは既存どおり手動無効の状態を維持します。

## 参照

- https://code.claude.com/docs/en/hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - Bashコマンドガードが入力内容をより厳密に検証し、不正・不完全な入力を安全側に判定するよう改善しました。
  - 危険なコマンドの拒否結果を安定して生成できるようになりました。
  - 必要なツールが利用できない場合も、理由を示して適切にブロックします。

- **ドキュメント**
  - Bashコマンドガードの対象範囲、制限事項、検証方法をREADMEに追加しました。

- **テスト**
  - 安全なコマンド、危険なコマンド、不正入力、各種エラーケースを網羅するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->