### PR TITLE
Markdown文書の行長エラーを解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Experimental repository for various tools.
 
 ## Bash command guard
 
-The [.claude/hooks/pre-bash-guard.sh](.claude/hooks/pre-bash-guard.sh) hook blocks representative direct Bash invocations that match its configured rules.
+The [Bash command guard](.claude/hooks/pre-bash-guard.sh)
+blocks representative direct Bash invocations that match its configured rules.
 
 - Requires `jq`
 - Blocks Bash calls with exit code `2` when the hook input cannot be validated
 - Allows valid commands that do not match a blocking rule
-- Does not comprehensively inspect wrappers, expansions, absolute paths, or other interpreters
+- Does not comprehensively inspect wrappers, expansions, absolute paths, or
+  other interpreters
 
 Run `./tests/pre-bash-guard.sh` to verify the guard.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,9 +3,12 @@
 ## Reporting Security Vulnerabilities
 
 Do not open a public issue for a suspected vulnerability or exposed credential.
-Use [GitHub private vulnerability reporting](https://github.com/pych-ky/tools-playground/security/advisories/new) instead.
+Use GitHub private vulnerability reporting instead:
 
-Include reproduction steps, impact, and a suggested fix when available, but do not include active credentials.
+<https://github.com/pych-ky/tools-playground/security/advisories/new>
+
+Include reproduction steps, impact, and a suggested fix when available, but do
+not include active credentials.
 
 ## Supported Versions
 


### PR DESCRIPTION
## 概要

- README とセキュリティポリシーの長い行を意味を変えずに改行
- セキュリティ報告先 URL を維持

## 検証

- `npx --yes markdownlint-cli2@0.23.1`（4文書、0 issues）
- `git diff --check`