### PR TITLE
CodeRabbitのレビュー強度を調整

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 language: ja-JP
 early_access: true
 reviews:
-  profile: assertive
+  profile: chill
   request_changes_workflow: true
   path_filters:
     # ビルド・出力ディレクトリ


### PR DESCRIPTION
## 変更内容

- CodeRabbit のレビュープロファイルを `assertive` から `chill` に変更
- `request_changes_workflow` を含むその他の設定は維持

## 変更理由

細かな文体・体裁上の指摘を抑え、重要なレビュー指摘へ集中しやすくするためです。
まずはプロファイルだけを変更し、追加設定を行わずに効果を切り分けます。

## 影響

CodeRabbit のレビュー強度のみが変わります。
リポジトリの実装やテスト動作への影響はありません。

## 検証

- PyYAML による `.coderabbit.yaml` の解析
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定**
  * コードレビューのトーンを、より穏やかな設定に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->